### PR TITLE
Add forgejo_container_add_host_domain_{name,ip_address}

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,21 @@ forgejo_config_root_url: "{{ forgejo_scheme }}://{{ forgejo_hostname }}{{ forgej
 # Unsetting this to an empty string makes it match. Unless you forgejo_uid accidentally hits some other user that is part of the container's /etc/passwd file.
 forgejo_config_run_user: "{{ 'git' if forgejo_uid | string == '1000' else '' }}"
 
+# When integrating Forgejo with Woodpecker CI, and if Woodpecker is
+# served under a subpath (e.g. `https://forgejo.host/ci`), it is
+# necessary to use Docker's `--add-host` option to point Forgejo to
+# the external host IP, so that webhook calls to Woodpecker can work.
+#
+# For example:
+#
+#  forgejo_container_add_host_domain_name: "{{ devture_woodpecker_ci_server_hostname }}"
+#  forgejo_container_add_host_domain_ip_address: "{{ ansible_host }}"
+#
+# Don't forget to also update `webhook.ALLOWED_HOST_LIST` on Forgejo's
+# app.ini config file.
+forgejo_container_add_host_domain_name: ''
+forgejo_container_add_host_domain_ip_address: ''
+
 # forgejo_container_labels_traefik_enabled controls whether labels to assist a Traefik reverse-proxy will be attached to the container.
 # See `roles/custom/forgejo/templates/labels.j2` for details.
 #

--- a/templates/forgejo.service.j2
+++ b/templates/forgejo.service.j2
@@ -27,6 +27,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% if forgejo_ssh_bind_port != '' %}
 			-p {{ forgejo_ssh_bind_port }}:2222 \
 			{% endif %}
+			{% if forgejo_container_add_host_domain_name %}
+			--add-host {{ forgejo_container_add_host_domain_name }}:{{ forgejo_container_add_host_domain_ip_address }} \
+			{% endif %}
 			--env-file={{ forgejo_base_path }}/env \
 			--label-file={{ forgejo_base_path }}/labels \
 			--mount type=bind,src={{ forgejo_data_dir_path }},dst=/var/lib/gitea \


### PR DESCRIPTION
These new configuration options are necessary when integrating Forgejo
with Woodpecker CI.  They are especially useful when Woodpecker CI is
running in a subpath along with Forgejo (e.g., Forgejo runs on
`https://forgejo.host` and Woodpecker CI runs on
`https://forgejo.host/ci`).