### PR TITLE
add variable forgejo_container_additional_networks_custom

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,7 +132,10 @@ forgejo_container_network: "{{ forgejo_identifier }}"
 
 # A list of additional container networks that the container would be connected to.
 # The playbook does not create these networks, so make sure they already exist.
-forgejo_container_additional_networks: []
+# Use this to expose this container to a reverse proxy, which runs in a different container network.
+forgejo_container_additional_networks: "{{ forgejo_container_additional_networks_auto + forgejo_container_additional_networks_custom }}"
+forgejo_container_additional_networks_auto: []
+forgejo_container_additional_networks_custom: []
 
 # Additional environment variables.
 forgejo_environment_variables_additional_variables: ''


### PR DESCRIPTION
by combining it with forgejo_container_additional_networks_auto to the normal forgejo_container_additional_networks_custom


I followed the syntax of the [ansible-role-gotosocial](https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial/blob/a6cb35db25e30f7c964d94542c21bf3d8a0be639/defaults/main.yml#L103C1-L108C52).